### PR TITLE
Add support and documentation for running without azure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# This example is for local development without Azure
+DISABLE_REDIS=true
+SECRET_Auth0Issuer=
+SECRET_Auth0Audience=
+SECRET_Auth0AdminClientId=
+SECRET_Auth0AdminClientId=
+SECRET_Auth0AdminClientSecret=
+SECRET_FRCApiKey="Basic KEY"
+SECRET_FRCCurrentSeason=2025
+SECRET_MailchimpAPIKey=
+SECRET_MailchimpAPIURL=
+SECRET_MailchimpListID=
+SECRET_TBAApiKey=
+SECRET_UserStorageConnectionString="UseDevelopmentStorage=true"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ npm i
 npm run start:no-redis
 ```
 
-The app won't be able to do anything without proper Azure key authentication. This means development outside our core team will be difficult.
+#### Configuring local development environment
+
+First configure gatool-ui according to the instructions for local development, including Auth0 setup. Then, install [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite). Start the Azurite blob store according to Microsoft's documentation. (If using VS Code, ensure you set the working directory in the extension settings to a directory outside of the repository or you will end up with a dirty repo.)
+
+Run `npm run create-dev-containers` to create the necessary containers in the blob store.
+
+Copy `.env.example` to `.env`
+Fill in the following variables:
+- Auth0Issuer with the domain used when setting up gatool-ui
+- Auth0Audience with the client id from setting up gatool-ui
+- FRCApiKey with the basic auth header (`Basic <base64(username:password)>`) for a [FRC API username/key](https://frc-events.firstinspires.org/services/api/register)
+- TBAApiKey with a [TBA Read API key](https://www.thebluealliance.com/account)
+
+Start the server using `npm run start:env` (or `npm run watch:env`)
 
 ### Deployment
 

--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
     "prestart": "npm run build",
     "start": "tsx src/app.ts",
     "start:no-redis": "export DISABLE_REDIS=true && tsx src/app.ts",
+    "start:env": "tsx --env-file .env src/app.ts",
     "watch": "tsx watch src/app.ts",
     "watch:no-redis": "export DISABLE_REDIS=true && tsx watch src/app.ts",
+    "watch:env": "tsx watch --env-file .env src/app.ts",
     "write-version": "echo $(git rev-parse HEAD) >> version.txt",
     "deploy:production": "pm2 deploy ecosystem.config.cjs production --force",
     "sync-users": "tsx src/cron/updateUsers.ts",
-    "update-high-scores": "tsx src/cron/updateHighScores.ts"
+    "update-high-scores": "tsx src/cron/updateHighScores.ts",
+    "create-dev-containers": "tsx src/utils/createDevContainers.ts"
   },
   "dependencies": {
     "@azure/identity": "4.6.0",

--- a/src/utils/createDevContainers.ts
+++ b/src/utils/createDevContainers.ts
@@ -1,0 +1,9 @@
+import { BlobServiceClient } from '@azure/storage-blob';
+
+const blobStorageConnectionString = "UseDevelopmentStorage=true"
+const blobServiceClient = BlobServiceClient.fromConnectionString(blobStorageConnectionString);
+
+blobServiceClient.createContainer('gatool-user-preferences');
+blobServiceClient.createContainer('gatool-team-updates');
+blobServiceClient.createContainer('gatool-team-updates-history');
+blobServiceClient.createContainer('gatool-high-scores');

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -35,8 +35,12 @@ export const StoreUserPreferences = async (userName: string, preferences: any) =
  */
 export const GetAnnouncements = async () => {
   const userBlob = userPrefsContainer.getBlockBlobClient(`system.announce.json`);
-  const content = await userBlob.download(0);
-  return await streamToString(content.readableStreamBody);
+  if(await userBlob.exists()) {
+    const content = await userBlob.download(0);
+    return await streamToString(content.readableStreamBody);
+  } else {
+    return 'null';
+  }
 };
 
 /**


### PR DESCRIPTION
This PR makes it easier to run and develop gatool-api without requiring access to azure or production Auth0.  I don't know if this is actually desired, but I did this work locally to be able to poke around the software and I figured it wouldn't hurt to make a PR out of it.

