### PR TITLE
Statbotics and ftcscout

### DIFF
--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -17,6 +17,7 @@ public class FrcApiController(
     ILogger<FrcApiController> logger,
     FRCApiService frcApiClient,
     TBAApiService tbaApiClient,
+    StatboticsApiService statboticsApiClient,
     IConnectionMultiplexer connectionMultiplexer,
     TeamDataService teamDataService,
     ScheduleService scheduleService)
@@ -431,6 +432,17 @@ public class FrcApiController(
             logger.LogError(ex, "Error fetching offseason events for year {Year}", year);
             return NoContent();
         }
+    }
+
+    [HttpGet("statbotics/{teamNumber}")]
+    [OpenApiTag("FRC Team Data")]
+    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    public async Task<IActionResult> GetStatboticsData(int year, string teamNumber)
+    {
+        var result = await statboticsApiClient.GetGeneric($"team_year/{teamNumber}/{year}");
+        if (result == null) return NoContent();
+        return Ok(result);
     }
 
     #region Private Methods

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -434,6 +434,14 @@ public class FrcApiController(
         }
     }
 
+    /// <summary>
+    /// Gets team statistics and data for a specific FRC team from Statbotics
+    /// </summary>
+    /// <param name="year">The competition year/season</param>
+    /// <param name="teamNumber">The FRC team number</param>
+    /// <returns>Team statistics and data from Statbotics API</returns>
+    /// <response code="200">Returns the team's statistics and data</response>
+    /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("statbotics/{teamNumber}")]
     [OpenApiTag("FRC Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using GAToolAPI.Attributes;
 using GAToolAPI.Extensions;
 using GAToolAPI.Models;

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -443,6 +443,7 @@ public class FrcApiController(
     /// <response code="200">Returns the team's statistics and data</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("statbotics/{teamNumber}")]
+    [RedisCache("statbotics:team-data", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FRC Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -446,7 +446,7 @@ public class FrcApiController(
     [HttpGet("statbotics/{teamNumber}")]
     [RedisCache("statbotics:team-data", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FRC Team Data")]
-    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(StatboticsTeamData), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public async Task<IActionResult> GetStatboticsData(int year, string teamNumber)
     {

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using GAToolAPI.Attributes;
 using GAToolAPI.Extensions;
 using GAToolAPI.Models;
@@ -443,6 +444,7 @@ public class FrcApiController(
     /// <response code="200">Returns the team's statistics and data</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("statbotics/{teamNumber}")]
+    [RedisCache("statbotics:team-data", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FRC Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -443,7 +443,6 @@ public class FrcApiController(
     /// <response code="200">Returns the team's statistics and data</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("statbotics/{teamNumber}")]
-    [RedisCache("statbotics:team-data", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FRC Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -223,7 +223,6 @@ public class FtcApiController(
     /// <response code="200">Returns the team's quick statistics</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
-    [RedisCache("ftcscout:quick-stats", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -243,7 +242,6 @@ public class FtcApiController(
     /// <response code="200">Returns the team's events data</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/events/{team}")]
-    [RedisCache("ftcscout:events", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -229,7 +229,7 @@ public class FtcApiController(
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public async Task<IActionResult> GetFtcScoutQuickStats(string year, string teamNumber)
     {
-        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/quick-stats?season={year}");
+        var result = await ftcScoutApi.Get<FtcScoutQuickStats>($"teams/{teamNumber}/quick-stats?season={year}");
         if (result == null) return NoContent();
         return Ok(result);
     }
@@ -249,7 +249,7 @@ public class FtcApiController(
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public async Task<IActionResult> GetFtcScoutEvents(string year, string teamNumber)
     {
-        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/events/{year}");
+        var result = await ftcScoutApi.Get<List<FtcScoutEventData>>($"teams/{teamNumber}/events/{year}");
         if (result == null) return NoContent();
         return Ok(result);
     }

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -15,7 +15,6 @@ namespace GAToolAPI.Controllers;
 public class FtcApiController(
     FTCApiService ftcApi,
     FTCScoutApiService ftcScoutApi,
-    TOAApiService toaApi,
     TeamDataService teamDataService,
     IConnectionMultiplexer connectionMultiplexer)
     : ControllerBase

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -223,7 +223,6 @@ public class FtcApiController(
     /// <response code="200">Returns the team's quick statistics</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
-    [RedisCache("ftcscoutapi:quick-stats:year:teamNumber", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -238,18 +237,17 @@ public class FtcApiController(
     /// Gets events data for a specific FTC team from FTC Scout
     /// </summary>
     /// <param name="year">The competition year/season</param>
-    /// <param name="teamNumber">The FTC team number</param>
+    /// <param name="team">The FTC team number</param>
     /// <returns>Events data from FTC Scout API</returns>
     /// <response code="200">Returns the team's events data</response>
     /// <response code="204">No data found for the specified team and year</response>
-    [HttpGet("ftcscout/events/{teamNumber}")]
-    [RedisCache("ftcscoutapi:events:year:teamNumber", RedisCacheTime.FiveMinutes)]
+    [HttpGet("ftcscout/events/{team}")]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetFtcScoutEvents(string year, string teamNumber)
+    public async Task<IActionResult> GetFtcScoutEvents(string year, string team)
     {
-        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/events/{year}");
+        var result = await ftcScoutApi.GetGeneric($"teams/{team}/events/{year}");
         if (result == null) return NoContent();
         return Ok(result);
     }

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -223,6 +223,7 @@ public class FtcApiController(
     /// <response code="200">Returns the team's quick statistics</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
+    [RedisCache("ftcscout:quick-stats", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -237,17 +238,18 @@ public class FtcApiController(
     /// Gets events data for a specific FTC team from FTC Scout
     /// </summary>
     /// <param name="year">The competition year/season</param>
-    /// <param name="team">The FTC team number</param>
+    /// <param name="teamNumber">The FTC team number</param>
     /// <returns>Events data from FTC Scout API</returns>
     /// <response code="200">Returns the team's events data</response>
     /// <response code="204">No data found for the specified team and year</response>
-    [HttpGet("ftcscout/events/{team}")]
+    [HttpGet("ftcscout/events/{teamNumber}")]
+    [RedisCache("ftcscout:events", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetFtcScoutEvents(string year, string team)
+    public async Task<IActionResult> GetFtcScoutEvents(string year, string teamNumber)
     {
-        var result = await ftcScoutApi.GetGeneric($"teams/{team}/events/{year}");
+        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/events/{year}");
         if (result == null) return NoContent();
         return Ok(result);
     }

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -223,6 +223,7 @@ public class FtcApiController(
     /// <response code="200">Returns the team's quick statistics</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
+    [RedisCache("ftcscoutapi:quick-stats:year:teamNumber", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -237,17 +238,18 @@ public class FtcApiController(
     /// Gets events data for a specific FTC team from FTC Scout
     /// </summary>
     /// <param name="year">The competition year/season</param>
-    /// <param name="team">The FTC team number</param>
+    /// <param name="teamNumber">The FTC team number</param>
     /// <returns>Events data from FTC Scout API</returns>
     /// <response code="200">Returns the team's events data</response>
     /// <response code="204">No data found for the specified team and year</response>
-    [HttpGet("ftcscout/events/{team}")]
+    [HttpGet("ftcscout/events/{teamNumber}")]
+    [RedisCache("ftcscoutapi:events:year:teamNumber", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetFtcScoutEvents(string year, string team)
+    public async Task<IActionResult> GetFtcScoutEvents(string year, string teamNumber)
     {
-        var result = await ftcScoutApi.GetGeneric($"teams/{team}/events/{year}");
+        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/events/{year}");
         if (result == null) return NoContent();
         return Ok(result);
     }

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -223,6 +223,7 @@ public class FtcApiController(
     /// <response code="200">Returns the team's quick statistics</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
+    [RedisCache("ftcscout:quick-stats", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -242,6 +243,7 @@ public class FtcApiController(
     /// <response code="200">Returns the team's events data</response>
     /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/events/{team}")]
+    [RedisCache("ftcscout:events", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -214,6 +214,14 @@ public class FtcApiController(
         return Ok(awards.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
     }
 
+    /// <summary>
+    /// Gets quick statistics for a specific FTC team from FTC Scout
+    /// </summary>
+    /// <param name="year">The competition year/season</param>
+    /// <param name="teamNumber">The FTC team number</param>
+    /// <returns>Quick statistics data from FTC Scout API</returns>
+    /// <response code="200">Returns the team's quick statistics</response>
+    /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
@@ -225,6 +233,14 @@ public class FtcApiController(
         return Ok(result);
     }
 
+    /// <summary>
+    /// Gets events data for a specific FTC team from FTC Scout
+    /// </summary>
+    /// <param name="year">The competition year/season</param>
+    /// <param name="team">The FTC team number</param>
+    /// <returns>Events data from FTC Scout API</returns>
+    /// <response code="200">Returns the team's events data</response>
+    /// <response code="204">No data found for the specified team and year</response>
     [HttpGet("ftcscout/events/{team}")]
     [OpenApiTag("FTC Scout Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -225,7 +225,7 @@ public class FtcApiController(
     [HttpGet("ftcscout/quick-stats/{teamNumber}")]
     [RedisCache("ftcscout:quick-stats", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
-    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(FtcScoutQuickStats), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public async Task<IActionResult> GetFtcScoutQuickStats(string year, string teamNumber)
     {
@@ -245,7 +245,7 @@ public class FtcApiController(
     [HttpGet("ftcscout/events/{teamNumber}")]
     [RedisCache("ftcscout:events", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Scout Team Data")]
-    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(List<FtcScoutEventData>), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public async Task<IActionResult> GetFtcScoutEvents(string year, string teamNumber)
     {

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -14,6 +14,7 @@ namespace GAToolAPI.Controllers;
 [Route("ftc/v2/{year}")]
 public class FtcApiController(
     FTCApiService ftcApi,
+    FTCScoutApiService ftcScoutApi,
     TOAApiService toaApi,
     TeamDataService teamDataService,
     IConnectionMultiplexer connectionMultiplexer)
@@ -211,6 +212,28 @@ public class FtcApiController(
         await Task.WhenAll(tasks);
 
         return Ok(awards.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+    }
+
+    [HttpGet("ftcscout/quick-stats/{teamNumber}")]
+    [OpenApiTag("FTC Scout Team Data")]
+    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    public async Task<IActionResult> GetFtcScoutQuickStats(string year, string teamNumber)
+    {
+        var result = await ftcScoutApi.GetGeneric($"teams/{teamNumber}/quick-stats?season={year}");
+        if (result == null) return NoContent();
+        return Ok(result);
+    }
+
+    [HttpGet("ftcscout/events/{team}")]
+    [OpenApiTag("FTC Scout Team Data")]
+    [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    public async Task<IActionResult> GetFtcScoutEvents(string year, string team)
+    {
+        var result = await ftcScoutApi.GetGeneric($"teams/{team}/events/{year}");
+        if (result == null) return NoContent();
+        return Ok(result);
     }
 
     #region Private Methods

--- a/Exceptions/ExternalApiException.cs
+++ b/Exceptions/ExternalApiException.cs
@@ -1,0 +1,15 @@
+using System.Net;
+
+namespace GAToolAPI.Exceptions;
+
+public class ExternalApiException(
+    string apiName,
+    HttpStatusCode statusCode,
+    string? responseBody = null,
+    string? message = null)
+    : Exception(message ?? $"{apiName} returned {(int)statusCode}: {statusCode}")
+{
+    public HttpStatusCode StatusCode { get; } = statusCode;
+    public string? ResponseBody { get; } = responseBody;
+    public string ApiName { get; } = apiName;
+}

--- a/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Text.Json;
+using GAToolAPI.Exceptions;
+
+namespace GAToolAPI.Middleware;
+
+public class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private async Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        logger.LogError(exception, "An unhandled exception occurred");
+
+        context.Response.ContentType = "application/json";
+
+        HttpStatusCode statusCode;
+        object response;
+
+        if (exception is ExternalApiException externalApiException)
+        {
+            // Preserve the status code from the external API
+            statusCode = externalApiException.StatusCode;
+
+            response = new
+            {
+                error = new
+                {
+                    message = externalApiException.Message,
+                    type = "ExternalApiError",
+                    apiName = externalApiException.ApiName,
+                    statusCode = (int)statusCode,
+                    details = externalApiException.ResponseBody
+                }
+            };
+        }
+        else
+        {
+            statusCode = exception switch
+            {
+                ArgumentException => HttpStatusCode.BadRequest,
+                UnauthorizedAccessException => HttpStatusCode.Unauthorized,
+                KeyNotFoundException => HttpStatusCode.NotFound,
+                _ => HttpStatusCode.InternalServerError
+            };
+
+            response = new
+            {
+                error = new
+                {
+                    message = exception.Message,
+                    type = exception.GetType().Name,
+                    statusCode = (int)statusCode
+                }
+            };
+        }
+
+        context.Response.StatusCode = (int)statusCode;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(response, options));
+    }
+}

--- a/Middleware/NewRelicRequestFilter.cs
+++ b/Middleware/NewRelicRequestFilter.cs
@@ -1,5 +1,3 @@
-using NewRelic.Api.Agent;
-
 namespace GAToolAPI.Middleware;
 
 public class NewRelicRequestFilter(RequestDelegate next)

--- a/Models/FTCScoutModels.cs
+++ b/Models/FTCScoutModels.cs
@@ -1,337 +1,335 @@
-using System.Text.Json.Serialization;
-
 namespace GAToolAPI.Models;
 
 /// <summary>
 /// FTC Scout team event data
 /// </summary>
-public class FtcScoutEventData
+public record FtcScoutEventData
 {
     /// <summary>
     /// The competition season/year
     /// </summary>
-    public int Season { get; set; }
+    public int? Season { get; init; }
 
     /// <summary>
     /// The event code
     /// </summary>
-    public string EventCode { get; set; } = string.Empty;
+    public string? EventCode { get; init; } = string.Empty;
 
     /// <summary>
     /// The team number
     /// </summary>
-    public int TeamNumber { get; set; }
+    public int? TeamNumber { get; init; }
 
     /// <summary>
     /// Whether this is a remote event
     /// </summary>
-    public bool IsRemote { get; set; }
+    public bool? IsRemote { get; init; }
 
     /// <summary>
     /// Team statistics for this event (null if no data available)
     /// </summary>
-    public FtcScoutEventStats? Stats { get; set; }
+    public FtcScoutEventStats? Stats { get; init; }
 
     /// <summary>
     /// When this record was created
     /// </summary>
-    public DateTime CreatedAt { get; set; }
+    public DateTime? CreatedAt { get; init; }
 
     /// <summary>
     /// When this record was last updated
     /// </summary>
-    public DateTime UpdatedAt { get; set; }
+    public DateTime? UpdatedAt { get; init; }
 }
 
 /// <summary>
 /// Detailed statistics for a team at an event
 /// </summary>
-public class FtcScoutEventStats
+public record FtcScoutEventStats
 {
     /// <summary>
     /// Team's rank at the event
     /// </summary>
-    public int Rank { get; set; }
+    public int? Rank { get; init; }
 
     /// <summary>
     /// Ranking points
     /// </summary>
-    public double Rp { get; set; }
+    public double? Rp { get; init; }
 
     /// <summary>
     /// First tiebreaker
     /// </summary>
-    public double Tb1 { get; set; }
+    public double? Tb1 { get; init; }
 
     /// <summary>
     /// Second tiebreaker
     /// </summary>
-    public double Tb2 { get; set; }
+    public double? Tb2 { get; init; }
 
     /// <summary>
     /// Number of wins
     /// </summary>
-    public int Wins { get; set; }
+    public int? Wins { get; init; }
 
     /// <summary>
     /// Number of losses
     /// </summary>
-    public int Losses { get; set; }
+    public int? Losses { get; init; }
 
     /// <summary>
     /// Number of ties
     /// </summary>
-    public int Ties { get; set; }
+    public int? Ties { get; init; }
 
     /// <summary>
     /// Number of disqualifications
     /// </summary>
-    public int Dqs { get; set; }
+    public int? Dqs { get; init; }
 
     /// <summary>
     /// Number of qualification matches played
     /// </summary>
-    public int QualMatchesPlayed { get; set; }
+    public int? QualMatchesPlayed { get; init; }
 
     /// <summary>
     /// Total statistics across all matches
     /// </summary>
-    public FtcScoutStatistics Tot { get; set; } = new();
+    public FtcScoutStatistics? Tot { get; init; } = new();
 
     /// <summary>
     /// Average statistics per match
     /// </summary>
-    public FtcScoutStatistics Avg { get; set; } = new();
+    public FtcScoutStatistics? Avg { get; init; } = new();
 
     /// <summary>
     /// OPR (Offensive Power Rating) statistics
     /// </summary>
-    public FtcScoutStatistics Opr { get; set; } = new();
+    public FtcScoutStatistics? Opr { get; init; } = new();
 
     /// <summary>
     /// Minimum values achieved
     /// </summary>
-    public FtcScoutStatistics Min { get; set; } = new();
+    public FtcScoutStatistics? Min { get; init; } = new();
 
     /// <summary>
     /// Maximum values achieved
     /// </summary>
-    public FtcScoutStatistics Max { get; set; } = new();
+    public FtcScoutStatistics? Max { get; init; } = new();
 
     /// <summary>
     /// Standard deviation of statistics
     /// </summary>
-    public FtcScoutStatistics Dev { get; set; } = new();
+    public FtcScoutStatistics? Dev { get; init; } = new();
 }
 
 /// <summary>
 /// Detailed FTC scoring statistics
 /// </summary>
-public class FtcScoutStatistics
+public record FtcScoutStatistics
 {
     // Auto Period - Parking
     /// <summary>
     /// Auto parking points
     /// </summary>
-    public double AutoParkPoints { get; set; }
+    public double? AutoParkPoints { get; init; }
 
     /// <summary>
     /// Auto parking points (individual)
     /// </summary>
-    public double AutoParkPointsIndividual { get; set; }
+    public double? AutoParkPointsIndividual { get; init; }
 
     // Auto Period - Samples
     /// <summary>
     /// Auto sample points
     /// </summary>
-    public double AutoSamplePoints { get; set; }
+    public double? AutoSamplePoints { get; init; }
 
     /// <summary>
     /// Auto sample net points
     /// </summary>
-    public double AutoSampleNetPoints { get; set; }
+    public double? AutoSampleNetPoints { get; init; }
 
     /// <summary>
     /// Auto sample low basket points
     /// </summary>
-    public double AutoSampleLowPoints { get; set; }
+    public double? AutoSampleLowPoints { get; init; }
 
     /// <summary>
     /// Auto sample high basket points
     /// </summary>
-    public double AutoSampleHighPoints { get; set; }
+    public double? AutoSampleHighPoints { get; init; }
 
     // Auto Period - Specimens
     /// <summary>
     /// Auto specimen points
     /// </summary>
-    public double AutoSpecimenPoints { get; set; }
+    public double? AutoSpecimenPoints { get; init; }
 
     /// <summary>
     /// Auto specimen low chamber points
     /// </summary>
-    public double AutoSpecimenLowPoints { get; set; }
+    public double? AutoSpecimenLowPoints { get; init; }
 
     /// <summary>
     /// Auto specimen high chamber points
     /// </summary>
-    public double AutoSpecimenHighPoints { get; set; }
+    public double? AutoSpecimenHighPoints { get; init; }
 
     // Driver Controlled Period - Parking
     /// <summary>
     /// Driver controlled parking points
     /// </summary>
-    public double DcParkPoints { get; set; }
+    public double? DcParkPoints { get; init; }
 
     /// <summary>
     /// Driver controlled parking points (individual)
     /// </summary>
-    public double DcParkPointsIndividual { get; set; }
+    public double? DcParkPointsIndividual { get; init; }
 
     // Driver Controlled Period - Samples
     /// <summary>
     /// Driver controlled sample points
     /// </summary>
-    public double DcSamplePoints { get; set; }
+    public double? DcSamplePoints { get; init; }
 
     /// <summary>
     /// Driver controlled sample net points
     /// </summary>
-    public double DcSampleNetPoints { get; set; }
+    public double? DcSampleNetPoints { get; init; }
 
     /// <summary>
     /// Driver controlled sample low basket points
     /// </summary>
-    public double DcSampleLowPoints { get; set; }
+    public double? DcSampleLowPoints { get; init; }
 
     /// <summary>
     /// Driver controlled sample high basket points
     /// </summary>
-    public double DcSampleHighPoints { get; set; }
+    public double? DcSampleHighPoints { get; init; }
 
     // Driver Controlled Period - Specimens
     /// <summary>
     /// Driver controlled specimen points
     /// </summary>
-    public double DcSpecimenPoints { get; set; }
+    public double? DcSpecimenPoints { get; init; }
 
     /// <summary>
     /// Driver controlled specimen low chamber points
     /// </summary>
-    public double DcSpecimenLowPoints { get; set; }
+    public double? DcSpecimenLowPoints { get; init; }
 
     /// <summary>
     /// Driver controlled specimen high chamber points
     /// </summary>
-    public double DcSpecimenHighPoints { get; set; }
+    public double? DcSpecimenHighPoints { get; init; }
 
     // Period Totals
     /// <summary>
     /// Total auto period points
     /// </summary>
-    public double AutoPoints { get; set; }
+    public double? AutoPoints { get; init; }
 
     /// <summary>
     /// Total driver controlled period points
     /// </summary>
-    public double DcPoints { get; set; }
+    public double? DcPoints { get; init; }
 
     // Penalties
     /// <summary>
     /// Major penalty points committed by team
     /// </summary>
-    public double MajorsCommittedPoints { get; set; }
+    public double? MajorsCommittedPoints { get; init; }
 
     /// <summary>
     /// Minor penalty points committed by team
     /// </summary>
-    public double MinorsCommittedPoints { get; set; }
+    public double? MinorsCommittedPoints { get; init; }
 
     /// <summary>
     /// Total penalty points committed by team
     /// </summary>
-    public double PenaltyPointsCommitted { get; set; }
+    public double? PenaltyPointsCommitted { get; init; }
 
     /// <summary>
     /// Major penalty points committed by opponents
     /// </summary>
-    public double MajorsByOppPoints { get; set; }
+    public double? MajorsByOppPoints { get; init; }
 
     /// <summary>
     /// Minor penalty points committed by opponents
     /// </summary>
-    public double MinorsByOppPoints { get; set; }
+    public double? MinorsByOppPoints { get; init; }
 
     /// <summary>
     /// Total penalty points committed by opponents
     /// </summary>
-    public double PenaltyPointsByOpp { get; set; }
+    public double? PenaltyPointsByOpp { get; init; }
 
     // Match Totals
     /// <summary>
     /// Total points excluding penalties
     /// </summary>
-    public double TotalPointsNp { get; set; }
+    public double? TotalPointsNp { get; init; }
 
     /// <summary>
     /// Total points including penalties
     /// </summary>
-    public double TotalPoints { get; set; }
+    public double? TotalPoints { get; init; }
 }
 
 /// <summary>
 /// Quick statistics summary for a team from FTC Scout
 /// </summary>
-public class FtcScoutQuickStats
+public record FtcScoutQuickStats
 {
     /// <summary>
     /// The competition season/year
     /// </summary>
-    public int Season { get; set; }
+    public int? Season { get; init; }
 
     /// <summary>
     /// Team number
     /// </summary>
-    public int Number { get; set; }
+    public int? Number { get; init; }
 
     /// <summary>
     /// Total OPR statistics (overall performance rating)
     /// </summary>
-    public FtcScoutStatRank Tot { get; set; } = new();
+    public FtcScoutStatRank? Tot { get; init; } = new();
 
     /// <summary>
     /// Auto period OPR statistics
     /// </summary>
-    public FtcScoutStatRank Auto { get; set; } = new();
+    public FtcScoutStatRank? Auto { get; init; } = new();
 
     /// <summary>
     /// Driver controlled period OPR statistics
     /// </summary>
-    public FtcScoutStatRank Dc { get; set; } = new();
+    public FtcScoutStatRank? Dc { get; init; } = new();
 
     /// <summary>
     /// End game OPR statistics
     /// </summary>
-    public FtcScoutStatRank Eg { get; set; } = new();
+    public FtcScoutStatRank? Eg { get; init; } = new();
 
     /// <summary>
     /// Total number of data points used in calculation
     /// </summary>
-    public int Count { get; set; }
+    public int? Count { get; init; }
 }
 
 /// <summary>
 /// Statistical value with ranking information
 /// </summary>
-public class FtcScoutStatRank
+public record FtcScoutStatRank
 {
     /// <summary>
     /// The statistical value (OPR rating)
     /// </summary>
-    public double Value { get; set; }
+    public double? Value { get; init; }
 
     /// <summary>
     /// The team's rank for this statistic
     /// </summary>
-    public int Rank { get; set; }
+    public int? Rank { get; init; }
 }

--- a/Models/FTCScoutModels.cs
+++ b/Models/FTCScoutModels.cs
@@ -1,0 +1,337 @@
+using System.Text.Json.Serialization;
+
+namespace GAToolAPI.Models;
+
+/// <summary>
+/// FTC Scout team event data
+/// </summary>
+public class FtcScoutEventData
+{
+    /// <summary>
+    /// The competition season/year
+    /// </summary>
+    public int Season { get; set; }
+
+    /// <summary>
+    /// The event code
+    /// </summary>
+    public string EventCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The team number
+    /// </summary>
+    public int TeamNumber { get; set; }
+
+    /// <summary>
+    /// Whether this is a remote event
+    /// </summary>
+    public bool IsRemote { get; set; }
+
+    /// <summary>
+    /// Team statistics for this event (null if no data available)
+    /// </summary>
+    public FtcScoutEventStats? Stats { get; set; }
+
+    /// <summary>
+    /// When this record was created
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// When this record was last updated
+    /// </summary>
+    public DateTime UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Detailed statistics for a team at an event
+/// </summary>
+public class FtcScoutEventStats
+{
+    /// <summary>
+    /// Team's rank at the event
+    /// </summary>
+    public int Rank { get; set; }
+
+    /// <summary>
+    /// Ranking points
+    /// </summary>
+    public double Rp { get; set; }
+
+    /// <summary>
+    /// First tiebreaker
+    /// </summary>
+    public double Tb1 { get; set; }
+
+    /// <summary>
+    /// Second tiebreaker
+    /// </summary>
+    public double Tb2 { get; set; }
+
+    /// <summary>
+    /// Number of wins
+    /// </summary>
+    public int Wins { get; set; }
+
+    /// <summary>
+    /// Number of losses
+    /// </summary>
+    public int Losses { get; set; }
+
+    /// <summary>
+    /// Number of ties
+    /// </summary>
+    public int Ties { get; set; }
+
+    /// <summary>
+    /// Number of disqualifications
+    /// </summary>
+    public int Dqs { get; set; }
+
+    /// <summary>
+    /// Number of qualification matches played
+    /// </summary>
+    public int QualMatchesPlayed { get; set; }
+
+    /// <summary>
+    /// Total statistics across all matches
+    /// </summary>
+    public FtcScoutStatistics Tot { get; set; } = new();
+
+    /// <summary>
+    /// Average statistics per match
+    /// </summary>
+    public FtcScoutStatistics Avg { get; set; } = new();
+
+    /// <summary>
+    /// OPR (Offensive Power Rating) statistics
+    /// </summary>
+    public FtcScoutStatistics Opr { get; set; } = new();
+
+    /// <summary>
+    /// Minimum values achieved
+    /// </summary>
+    public FtcScoutStatistics Min { get; set; } = new();
+
+    /// <summary>
+    /// Maximum values achieved
+    /// </summary>
+    public FtcScoutStatistics Max { get; set; } = new();
+
+    /// <summary>
+    /// Standard deviation of statistics
+    /// </summary>
+    public FtcScoutStatistics Dev { get; set; } = new();
+}
+
+/// <summary>
+/// Detailed FTC scoring statistics
+/// </summary>
+public class FtcScoutStatistics
+{
+    // Auto Period - Parking
+    /// <summary>
+    /// Auto parking points
+    /// </summary>
+    public double AutoParkPoints { get; set; }
+
+    /// <summary>
+    /// Auto parking points (individual)
+    /// </summary>
+    public double AutoParkPointsIndividual { get; set; }
+
+    // Auto Period - Samples
+    /// <summary>
+    /// Auto sample points
+    /// </summary>
+    public double AutoSamplePoints { get; set; }
+
+    /// <summary>
+    /// Auto sample net points
+    /// </summary>
+    public double AutoSampleNetPoints { get; set; }
+
+    /// <summary>
+    /// Auto sample low basket points
+    /// </summary>
+    public double AutoSampleLowPoints { get; set; }
+
+    /// <summary>
+    /// Auto sample high basket points
+    /// </summary>
+    public double AutoSampleHighPoints { get; set; }
+
+    // Auto Period - Specimens
+    /// <summary>
+    /// Auto specimen points
+    /// </summary>
+    public double AutoSpecimenPoints { get; set; }
+
+    /// <summary>
+    /// Auto specimen low chamber points
+    /// </summary>
+    public double AutoSpecimenLowPoints { get; set; }
+
+    /// <summary>
+    /// Auto specimen high chamber points
+    /// </summary>
+    public double AutoSpecimenHighPoints { get; set; }
+
+    // Driver Controlled Period - Parking
+    /// <summary>
+    /// Driver controlled parking points
+    /// </summary>
+    public double DcParkPoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled parking points (individual)
+    /// </summary>
+    public double DcParkPointsIndividual { get; set; }
+
+    // Driver Controlled Period - Samples
+    /// <summary>
+    /// Driver controlled sample points
+    /// </summary>
+    public double DcSamplePoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled sample net points
+    /// </summary>
+    public double DcSampleNetPoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled sample low basket points
+    /// </summary>
+    public double DcSampleLowPoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled sample high basket points
+    /// </summary>
+    public double DcSampleHighPoints { get; set; }
+
+    // Driver Controlled Period - Specimens
+    /// <summary>
+    /// Driver controlled specimen points
+    /// </summary>
+    public double DcSpecimenPoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled specimen low chamber points
+    /// </summary>
+    public double DcSpecimenLowPoints { get; set; }
+
+    /// <summary>
+    /// Driver controlled specimen high chamber points
+    /// </summary>
+    public double DcSpecimenHighPoints { get; set; }
+
+    // Period Totals
+    /// <summary>
+    /// Total auto period points
+    /// </summary>
+    public double AutoPoints { get; set; }
+
+    /// <summary>
+    /// Total driver controlled period points
+    /// </summary>
+    public double DcPoints { get; set; }
+
+    // Penalties
+    /// <summary>
+    /// Major penalty points committed by team
+    /// </summary>
+    public double MajorsCommittedPoints { get; set; }
+
+    /// <summary>
+    /// Minor penalty points committed by team
+    /// </summary>
+    public double MinorsCommittedPoints { get; set; }
+
+    /// <summary>
+    /// Total penalty points committed by team
+    /// </summary>
+    public double PenaltyPointsCommitted { get; set; }
+
+    /// <summary>
+    /// Major penalty points committed by opponents
+    /// </summary>
+    public double MajorsByOppPoints { get; set; }
+
+    /// <summary>
+    /// Minor penalty points committed by opponents
+    /// </summary>
+    public double MinorsByOppPoints { get; set; }
+
+    /// <summary>
+    /// Total penalty points committed by opponents
+    /// </summary>
+    public double PenaltyPointsByOpp { get; set; }
+
+    // Match Totals
+    /// <summary>
+    /// Total points excluding penalties
+    /// </summary>
+    public double TotalPointsNp { get; set; }
+
+    /// <summary>
+    /// Total points including penalties
+    /// </summary>
+    public double TotalPoints { get; set; }
+}
+
+/// <summary>
+/// Quick statistics summary for a team from FTC Scout
+/// </summary>
+public class FtcScoutQuickStats
+{
+    /// <summary>
+    /// The competition season/year
+    /// </summary>
+    public int Season { get; set; }
+
+    /// <summary>
+    /// Team number
+    /// </summary>
+    public int Number { get; set; }
+
+    /// <summary>
+    /// Total OPR statistics (overall performance rating)
+    /// </summary>
+    public FtcScoutStatRank Tot { get; set; } = new();
+
+    /// <summary>
+    /// Auto period OPR statistics
+    /// </summary>
+    public FtcScoutStatRank Auto { get; set; } = new();
+
+    /// <summary>
+    /// Driver controlled period OPR statistics
+    /// </summary>
+    public FtcScoutStatRank Dc { get; set; } = new();
+
+    /// <summary>
+    /// End game OPR statistics
+    /// </summary>
+    public FtcScoutStatRank Eg { get; set; } = new();
+
+    /// <summary>
+    /// Total number of data points used in calculation
+    /// </summary>
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// Statistical value with ranking information
+/// </summary>
+public class FtcScoutStatRank
+{
+    /// <summary>
+    /// The statistical value (OPR rating)
+    /// </summary>
+    public double Value { get; set; }
+
+    /// <summary>
+    /// The team's rank for this statistic
+    /// </summary>
+    public int Rank { get; set; }
+}

--- a/Models/StatboticsModels.cs
+++ b/Models/StatboticsModels.cs
@@ -1,0 +1,388 @@
+using System.Text.Json.Serialization;
+
+namespace GAToolAPI.Models;
+
+/// <summary>
+/// Team statistics and data from Statbotics API
+/// </summary>
+public class StatboticsTeamData
+{
+    /// <summary>
+    /// Team number
+    /// </summary>
+    public int Team { get; set; }
+
+    /// <summary>
+    /// Competition year
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
+    /// Team name
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Country code
+    /// </summary>
+    public string Country { get; set; } = string.Empty;
+
+    /// <summary>
+    /// State/province code
+    /// </summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>
+    /// District code (if applicable)
+    /// </summary>
+    public string? District { get; set; }
+
+    /// <summary>
+    /// Team's rookie year
+    /// </summary>
+    [JsonPropertyName("rookie_year")]
+    public int RookieYear { get; set; }
+
+    /// <summary>
+    /// Expected Points Added (EPA) statistics
+    /// </summary>
+    public StatboticsEpa Epa { get; set; } = new();
+
+    /// <summary>
+    /// Win-loss record for the season
+    /// </summary>
+    public StatboticsRecord Record { get; set; } = new();
+
+    /// <summary>
+    /// District points earned (if applicable)
+    /// </summary>
+    [JsonPropertyName("district_points")]
+    public int? DistrictPoints { get; set; }
+
+    /// <summary>
+    /// District ranking (if applicable)
+    /// </summary>
+    [JsonPropertyName("district_rank")]
+    public int? DistrictRank { get; set; }
+}
+
+/// <summary>
+/// Expected Points Added (EPA) statistics and breakdowns
+/// </summary>
+public class StatboticsEpa
+{
+    /// <summary>
+    /// Total points statistics
+    /// </summary>
+    [JsonPropertyName("total_points")]
+    public StatboticsStatistic TotalPoints { get; set; } = new();
+
+    /// <summary>
+    /// Unitless EPA rating
+    /// </summary>
+    public double Unitless { get; set; }
+
+    /// <summary>
+    /// Normalized EPA rating
+    /// </summary>
+    public double Norm { get; set; }
+
+    /// <summary>
+    /// Confidence interval [lower, upper]
+    /// </summary>
+    public double[] Conf { get; set; } = new double[2];
+
+    /// <summary>
+    /// Detailed breakdown of EPA by game component
+    /// </summary>
+    public StatboticsBreakdown Breakdown { get; set; } = new();
+
+    /// <summary>
+    /// EPA statistics over time
+    /// </summary>
+    public StatboticsStats Stats { get; set; } = new();
+
+    /// <summary>
+    /// Rankings at different levels (global, country, state, district)
+    /// </summary>
+    public StatboticsRanks Ranks { get; set; } = new();
+}
+
+/// <summary>
+/// Statistical value with mean and standard deviation
+/// </summary>
+public class StatboticsStatistic
+{
+    /// <summary>
+    /// Mean value
+    /// </summary>
+    public double Mean { get; set; }
+
+    /// <summary>
+    /// Standard deviation
+    /// </summary>
+    public double Sd { get; set; }
+}
+
+/// <summary>
+/// Detailed breakdown of EPA by game component (2024 Crescendo specific)
+/// </summary>
+public class StatboticsBreakdown
+{
+    /// <summary>
+    /// Total points contributed
+    /// </summary>
+    [JsonPropertyName("total_points")]
+    public double TotalPoints { get; set; }
+
+    /// <summary>
+    /// Auto period points
+    /// </summary>
+    [JsonPropertyName("auto_points")]
+    public double AutoPoints { get; set; }
+
+    /// <summary>
+    /// Teleop period points
+    /// </summary>
+    [JsonPropertyName("teleop_points")]
+    public double TeleopPoints { get; set; }
+
+    /// <summary>
+    /// Endgame period points
+    /// </summary>
+    [JsonPropertyName("endgame_points")]
+    public double EndgamePoints { get; set; }
+
+    /// <summary>
+    /// Melody ranking point contribution
+    /// </summary>
+    [JsonPropertyName("melody_rp")]
+    public double MelodyRp { get; set; }
+
+    /// <summary>
+    /// Ensemble ranking point contribution
+    /// </summary>
+    [JsonPropertyName("ensemble_rp")]
+    public double EnsembleRp { get; set; }
+
+    /// <summary>
+    /// Tiebreaker points
+    /// </summary>
+    [JsonPropertyName("tiebreaker_points")]
+    public double TiebreakerPoints { get; set; }
+
+    /// <summary>
+    /// Auto leave points
+    /// </summary>
+    [JsonPropertyName("auto_leave_points")]
+    public double AutoLeavePoints { get; set; }
+
+    /// <summary>
+    /// Auto notes scored
+    /// </summary>
+    [JsonPropertyName("auto_notes")]
+    public double AutoNotes { get; set; }
+
+    /// <summary>
+    /// Auto note points
+    /// </summary>
+    [JsonPropertyName("auto_note_points")]
+    public double AutoNotePoints { get; set; }
+
+    /// <summary>
+    /// Teleop notes scored
+    /// </summary>
+    [JsonPropertyName("teleop_notes")]
+    public double TeleopNotes { get; set; }
+
+    /// <summary>
+    /// Teleop note points
+    /// </summary>
+    [JsonPropertyName("teleop_note_points")]
+    public double TeleopNotePoints { get; set; }
+
+    /// <summary>
+    /// Amp notes scored
+    /// </summary>
+    [JsonPropertyName("amp_notes")]
+    public double AmpNotes { get; set; }
+
+    /// <summary>
+    /// Amp points
+    /// </summary>
+    [JsonPropertyName("amp_points")]
+    public double AmpPoints { get; set; }
+
+    /// <summary>
+    /// Speaker notes scored
+    /// </summary>
+    [JsonPropertyName("speaker_notes")]
+    public double SpeakerNotes { get; set; }
+
+    /// <summary>
+    /// Speaker points
+    /// </summary>
+    [JsonPropertyName("speaker_points")]
+    public double SpeakerPoints { get; set; }
+
+    /// <summary>
+    /// Amplified notes scored
+    /// </summary>
+    [JsonPropertyName("amplified_notes")]
+    public double AmplifiedNotes { get; set; }
+
+    /// <summary>
+    /// Total notes scored
+    /// </summary>
+    [JsonPropertyName("total_notes")]
+    public double TotalNotes { get; set; }
+
+    /// <summary>
+    /// Total note points
+    /// </summary>
+    [JsonPropertyName("total_note_points")]
+    public double TotalNotePoints { get; set; }
+
+    /// <summary>
+    /// Endgame park points
+    /// </summary>
+    [JsonPropertyName("endgame_park_points")]
+    public double EndgameParkPoints { get; set; }
+
+    /// <summary>
+    /// Endgame on stage points
+    /// </summary>
+    [JsonPropertyName("endgame_on_stage_points")]
+    public double EndgameOnStagePoints { get; set; }
+
+    /// <summary>
+    /// Endgame harmony points
+    /// </summary>
+    [JsonPropertyName("endgame_harmony_points")]
+    public double EndgameHarmonyPoints { get; set; }
+
+    /// <summary>
+    /// Endgame trap points
+    /// </summary>
+    [JsonPropertyName("endgame_trap_points")]
+    public double EndgameTrapPoints { get; set; }
+
+    /// <summary>
+    /// Endgame spotlight points
+    /// </summary>
+    [JsonPropertyName("endgame_spotlight_points")]
+    public double EndgameSpotlightPoints { get; set; }
+
+    /// <summary>
+    /// First ranking point contribution
+    /// </summary>
+    [JsonPropertyName("rp_1")]
+    public double Rp1 { get; set; }
+
+    /// <summary>
+    /// Second ranking point contribution
+    /// </summary>
+    [JsonPropertyName("rp_2")]
+    public double Rp2 { get; set; }
+}
+
+/// <summary>
+/// EPA statistics over time
+/// </summary>
+public class StatboticsStats
+{
+    /// <summary>
+    /// EPA at start of season
+    /// </summary>
+    public double Start { get; set; }
+
+    /// <summary>
+    /// EPA before championships
+    /// </summary>
+    [JsonPropertyName("pre_champs")]
+    public double PreChamps { get; set; }
+
+    /// <summary>
+    /// Maximum EPA achieved
+    /// </summary>
+    public double Max { get; set; }
+}
+
+/// <summary>
+/// Rankings at different competitive levels
+/// </summary>
+public class StatboticsRanks
+{
+    /// <summary>
+    /// Global ranking
+    /// </summary>
+    public StatboticsRank Total { get; set; } = new();
+
+    /// <summary>
+    /// Country ranking
+    /// </summary>
+    public StatboticsRank Country { get; set; } = new();
+
+    /// <summary>
+    /// State/province ranking
+    /// </summary>
+    public StatboticsRank State { get; set; } = new();
+
+    /// <summary>
+    /// District ranking (if applicable)
+    /// </summary>
+    public StatboticsRank? District { get; set; }
+}
+
+/// <summary>
+/// Ranking information at a specific level
+/// </summary>
+public class StatboticsRank
+{
+    /// <summary>
+    /// Numerical rank
+    /// </summary>
+    public int Rank { get; set; }
+
+    /// <summary>
+    /// Percentile ranking (0-1)
+    /// </summary>
+    public double Percentile { get; set; }
+
+    /// <summary>
+    /// Total number of teams in this ranking pool
+    /// </summary>
+    [JsonPropertyName("team_count")]
+    public int TeamCount { get; set; }
+}
+
+/// <summary>
+/// Win-loss record information
+/// </summary>
+public class StatboticsRecord
+{
+    /// <summary>
+    /// Number of wins
+    /// </summary>
+    public int Wins { get; set; }
+
+    /// <summary>
+    /// Number of losses
+    /// </summary>
+    public int Losses { get; set; }
+
+    /// <summary>
+    /// Number of ties
+    /// </summary>
+    public int Ties { get; set; }
+
+    /// <summary>
+    /// Total number of matches
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>
+    /// Win rate (0-1)
+    /// </summary>
+    public double Winrate { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -112,7 +112,9 @@ try
 
     builder.Services.AddSingleton<FRCApiService>();
     builder.Services.AddSingleton<TBAApiService>();
+    builder.Services.AddSingleton<StatboticsApiService>();
     builder.Services.AddSingleton<FTCApiService>();
+    builder.Services.AddSingleton<FTCScoutApiService>();
     builder.Services.AddSingleton<TOAApiService>();
     builder.Services.AddSingleton<UserStorageService>();
     builder.Services.AddSingleton<TeamDataService>();

--- a/Program.cs
+++ b/Program.cs
@@ -149,6 +149,7 @@ try
         return;
     }
 
+    app.UseMiddleware<ExceptionHandlingMiddleware>();
     app.UseSerilogRequestLogging();
     app.UseMiddleware<NewRelicRequestFilter>();
     app.UseOpenApi();

--- a/Services/FRCApiService.cs
+++ b/Services/FRCApiService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Security.KeyVault.Secrets;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
 
@@ -32,12 +33,20 @@ public class FRCApiService : IApiService
     public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonObject>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FRC API", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FRC API", response.StatusCode, errorContent);
     }
 }

--- a/Services/FTCApiService.cs
+++ b/Services/FTCApiService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Security.KeyVault.Secrets;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
 
@@ -32,12 +33,20 @@ public class FTCApiService : IApiService
     public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonObject>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FTC API", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FTC API", response.StatusCode, errorContent);
     }
 }

--- a/Services/FTCScoutApiService.cs
+++ b/Services/FTCScoutApiService.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace GAToolAPI.Services;
+
+public class FTCScoutApiService : IApiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public FTCScoutApiService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri("https://api.ftcscout.org/rest/v1/");
+
+        // Configure case-insensitive JSON options
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
+    {
+        var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
+        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+    }
+
+    public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
+    {
+        var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
+        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+    }
+}

--- a/Services/FTCScoutApiService.cs
+++ b/Services/FTCScoutApiService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace GAToolAPI.Services;
@@ -25,12 +26,20 @@ public class FTCScoutApiService : IApiService
     public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonObject>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FTC Scout", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("FTC Scout", response.StatusCode, errorContent);
     }
 }

--- a/Services/StatboticsApiService.cs
+++ b/Services/StatboticsApiService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace GAToolAPI.Services;
@@ -25,12 +26,20 @@ public class StatboticsApiService : IApiService
     public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonObject>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("Statbotics", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("Statbotics", response.StatusCode, errorContent);
     }
 }

--- a/Services/StatboticsApiService.cs
+++ b/Services/StatboticsApiService.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace GAToolAPI.Services;
+
+public class StatboticsApiService : IApiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public StatboticsApiService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri("https://statbotics.io/v3/");
+
+        // Configure case-insensitive JSON options
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<JsonObject?> GetGeneric(string path, IDictionary<string, string?>? query = null)
+    {
+        var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
+        return await _httpClient.GetFromJsonAsync<JsonObject>(requestUrl, _jsonOptions);
+    }
+
+    public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
+    {
+        var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
+        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+    }
+}

--- a/Services/TBAApiService.cs
+++ b/Services/TBAApiService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Security.KeyVault.Secrets;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
 
@@ -31,12 +32,20 @@ public class TBAApiService
     public async Task<JsonArray?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonArray>(requestUrl);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonArray>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("The Blue Alliance", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("The Blue Alliance", response.StatusCode, errorContent);
     }
 }

--- a/Services/TOAApiService.cs
+++ b/Services/TOAApiService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Security.KeyVault.Secrets;
+using GAToolAPI.Exceptions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
 
@@ -33,12 +34,20 @@ public class TOAApiService
     public async Task<JsonArray?> GetGeneric(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<JsonArray>(requestUrl);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<JsonArray>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("The Orange Alliance", response.StatusCode, errorContent);
     }
 
     public async Task<T?> Get<T>(string path, IDictionary<string, string?>? query = null)
     {
         var requestUrl = query != null ? QueryHelpers.AddQueryString(path, query) : path;
-        return await _httpClient.GetFromJsonAsync<T>(requestUrl, _jsonOptions);
+        var response = await _httpClient.GetAsync(requestUrl);
+
+        if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);
+        var errorContent = await response.Content.ReadAsStringAsync();
+        throw new ExternalApiException("The Orange Alliance", response.StatusCode, errorContent);
     }
 }


### PR DESCRIPTION
Adding endpoints for Statbotics and FTC Scout
This is necessary to reduce the number of endpoints that the client must access. Additionally, it ensures that we can offer an unsecured option for FTC Local Servers.