### PR TITLE
Making the Offseason Teams endpoint consistent with the others.

### DIFF
--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -355,7 +355,7 @@ public class FrcApiController(
 
         try
         {
-            var tbaResponse = await tbaApiClient.Get<List<TBATeam>>($"event/{eventCode}/teams");
+            var tbaResponse = await tbaApiClient.Get<List<TBATeam>>($"event/{year}{eventCode}/teams");
             if (tbaResponse == null || tbaResponse.Count == 0) return NoContent();
 
             // Sort teams by team number


### PR DESCRIPTION
The new endpoints create the TBA-style event name on the fly. The Teams endpoint does that now.