### PR TITLE
Supporting alphanumeric team numbers for Team Updates

### DIFF
--- a/Controllers/FRCTeamUpdatesController.cs
+++ b/Controllers/FRCTeamUpdatesController.cs
@@ -12,10 +12,10 @@ namespace GAToolAPI.Controllers;
 [OpenApiTag("Community Updates")]
 public class FrcTeamUpdatesController(UserStorageService userStorage, TeamDataService teamData) : ControllerBase
 {
-    [HttpGet("team/{teamNumber:int}/updates")]
+    [HttpGet("team/{teamNumber}/updates")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetTeamUpdatesForTeam(int teamNumber)
+    public async Task<IActionResult> GetTeamUpdatesForTeam(string teamNumber)
     {
         var teamUpdate = await userStorage.GetTeamUpdates(teamNumber);
         if (teamUpdate == null)
@@ -31,19 +31,19 @@ public class FrcTeamUpdatesController(UserStorageService userStorage, TeamDataSe
         });
     }
 
-    [HttpGet("team/{teamNumber:int}/updates/history")]
+    [HttpGet("team/{teamNumber}/updates/history")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetTeamUpdateHistory(int teamNumber)
+    public async Task<IActionResult> GetTeamUpdateHistory(string teamNumber)
     {
         var updateHistory = await userStorage.GetTeamUpdateHistory(teamNumber);
         return Ok(updateHistory);
     }
 
-    [HttpPut("team/{teamNumber:int}/updates")]
+    [HttpPut("team/{teamNumber}/updates")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [Authorize("user")]
-    public async Task<IActionResult> StoreTeamUpdatesForTeam([FromBody] JsonObject updates, int teamNumber)
+    public async Task<IActionResult> StoreTeamUpdatesForTeam([FromBody] JsonObject updates, string teamNumber)
     {
         var email = User.FindFirst("name")?.Value;
         if (email == null) return BadRequest("Missing user email address in token");
@@ -57,11 +57,11 @@ public class FrcTeamUpdatesController(UserStorageService userStorage, TeamDataSe
     public async Task<IActionResult> GetTeamUpdatesForEvent(string year, string eventCode)
     {
         var teamList = await teamData.GetFrcTeamData(year, eventCode);
-        var teamNumbers = teamList?.Teams?.Select(t => t.TeamNumber);
+        var teamNumbers = teamList?.Teams?.Select(t => t.TeamNumber.ToString());
         if (teamNumbers == null) return NoContent();
         var tasks = teamNumbers.Select(async t =>
         {
-            var update = await userStorage.GetTeamUpdates((int)t);
+            var update = await userStorage.GetTeamUpdates(t);
             return string.IsNullOrWhiteSpace(update) ? null : new
             {
                 teamNumber = t,

--- a/Controllers/FTCTeamUpdatesController.cs
+++ b/Controllers/FTCTeamUpdatesController.cs
@@ -12,10 +12,10 @@ namespace GAToolAPI.Controllers;
 [OpenApiTag("Community Updates")]
 public class FtcTeamUpdatesController(UserStorageService userStorage, TeamDataService teamData): ControllerBase
 {
-    [HttpGet("team/{teamNumber:int}/updates")]
+    [HttpGet("team/{teamNumber}/updates")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetTeamUpdatesForTeam(int teamNumber)
+    public async Task<IActionResult> GetTeamUpdatesForTeam(string teamNumber)
     {
         var teamUpdate = await userStorage.GetTeamUpdates(teamNumber, true);
         if (teamUpdate == null)
@@ -31,19 +31,19 @@ public class FtcTeamUpdatesController(UserStorageService userStorage, TeamDataSe
         });
     }
 
-    [HttpGet("team/{teamNumber:int}/updates/history")]
+    [HttpGet("team/{teamNumber}/updates/history")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IActionResult> GetTeamUpdateHistory(int teamNumber)
+    public async Task<IActionResult> GetTeamUpdateHistory(string teamNumber)
     {
         var updateHistory = await userStorage.GetTeamUpdateHistory(teamNumber, true);
         return Ok(updateHistory);
     }
 
-    [HttpPut("team/{teamNumber:int}/updates")]
+    [HttpPut("team/{teamNumber}/updates")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [Authorize("user")]
-    public async Task<IActionResult> StoreTeamUpdatesForTeam([FromBody] JsonObject updates, int teamNumber)
+    public async Task<IActionResult> StoreTeamUpdatesForTeam([FromBody] JsonObject updates, string teamNumber)
     {
         var email = User.FindFirst("name")?.Value;
         if (email == null) return BadRequest("Missing user email address in token");
@@ -59,12 +59,12 @@ public class FtcTeamUpdatesController(UserStorageService userStorage, TeamDataSe
         var teamList = await teamData.GetFtcTeamData(year, eventCode);
         if (teamList == null) return NoContent();
 
-        var teamNumbers = teamList?["teams"]?.AsArray().Select(t => t?["teamNumber"]?.GetValue<int>());
+        var teamNumbers = teamList?["teams"]?.AsArray().Select(t => t?["teamNumber"]?.ToString());
         if (teamNumbers == null) return NoContent();
         var tasks = teamNumbers.Select(async t =>
         {
             if (t == null) return null;
-            var update = await userStorage.GetTeamUpdates((int)t, true);
+            var update = await userStorage.GetTeamUpdates(t, true);
             return string.IsNullOrWhiteSpace(update) ? null : new
             {
                 teamNumber = t,

--- a/Services/UserStorageService.cs
+++ b/Services/UserStorageService.cs
@@ -94,7 +94,7 @@ public class UserStorageService(BlobServiceClient blobServiceClient, ILogger<Use
         await writer.WriteAsync(prefString);
     }
 
-    public async Task<string?> GetTeamUpdates(int teamNumber, bool ftc = false)
+    public async Task<string?> GetTeamUpdates(string teamNumber, bool ftc = false)
     {
         try
         {
@@ -111,7 +111,7 @@ public class UserStorageService(BlobServiceClient blobServiceClient, ILogger<Use
         }
     }
 
-    public async Task StoreTeamUpdates(int teamNumber, JsonObject data, string email, bool ftc = false)
+    public async Task StoreTeamUpdates(string teamNumber, JsonObject data, string email, bool ftc = false)
     {
         var blobPrefix = ftc ? "ftc/" : "";
         var updateBlobName = $"{blobPrefix}{teamNumber}.json";
@@ -146,7 +146,7 @@ public class UserStorageService(BlobServiceClient blobServiceClient, ILogger<Use
         await writer.WriteAsync(dataString);
     }
 
-    public async Task<IEnumerable<JsonObject>> GetTeamUpdateHistory(int teamNumber, bool ftc = false)
+    public async Task<IEnumerable<JsonObject>> GetTeamUpdateHistory(string teamNumber, bool ftc = false)
     {
         var results = new List<JsonObject>();
 


### PR DESCRIPTION
Some FTC teams have numbers like 12345A and 12345B. We want to support these in teamUpdate calls, so we need to support alphanumeric values for the team numbers in these operations.