### PR TITLE
Adding team history endpoint

### DIFF
--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -221,6 +221,28 @@ public class FrcApiController(
         return Ok(media.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
     }
 
+    [HttpGet("team/{teamNumber:int}/history")]
+    [RedisCache("tbaapi:teamhistory", RedisCacheTime.OneWeek)]
+    [OpenApiTag("FRC Team Data")]
+    [ProducesResponseType(typeof(TBATeamHistory), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    public async Task<IActionResult> GetTeamHistory(int year, int teamNumber)
+    {
+        Response.Headers.CacheControl = "s-maxage=604800"; // 1 week
+
+        try
+        {
+            var history = await tbaApiClient.Get<TBATeamHistory>($"team/frc{teamNumber}/history");
+            if (history == null) return NoContent();
+            return Ok(history);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching team history for team {TeamNumber}", teamNumber);
+            return NoContent();
+        }
+    }
+
     [HttpGet("avatars/team/{teamNumber:int}/avatar.png")]
     [RedisCache("frc:teamavatar", RedisCacheTime.OneMonth)]
     [OpenApiTag("FRC Team Data")]

--- a/Models/TBAModels.cs
+++ b/Models/TBAModels.cs
@@ -184,3 +184,24 @@ public class TBAEventRankings
     public List<TBARanking>? Rankings { get; set; }
     [JsonPropertyName("sort_order_info")] public List<TBASortOrderInfo>? SortOrderInfo { get; set; }
 }
+
+[UsedImplicitly]
+public record RawTbaAwardRecipient(
+    [property: JsonPropertyName("awardee")] string? Awardee,
+    [property: JsonPropertyName("team_key")] string? TeamKey
+);
+
+[UsedImplicitly]
+public record RawTbaAward(
+    [property: JsonPropertyName("award_type")] int? AwardType,
+    [property: JsonPropertyName("event_key")] string? EventKey,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("recipient_list")] List<RawTbaAwardRecipient>? RecipientList,
+    [property: JsonPropertyName("year")] int? Year
+);
+
+[UsedImplicitly]
+public record TBATeamHistory(
+    [property: JsonPropertyName("awards")] List<RawTbaAward>? Awards,
+    [property: JsonPropertyName("events")] List<RawTbaEvent>? Events
+);


### PR DESCRIPTION
We have historically used the TBA Events endpoint to record appearances at Champs events. There is another endpoint that includes all of these data but also the team's award history. Using the new endpoint, we can consolidate multiple calls into one.