### PR TITLE
Add support for TBA team remapping in offseason events

### DIFF
--- a/Controllers/FRCApiController.cs
+++ b/Controllers/FRCApiController.cs
@@ -1059,7 +1059,7 @@ public class FrcApiController(
                     tbaRanking.Record?.Wins ?? 0,
                     tbaRanking.Record?.Losses ?? 0,
                     tbaRanking.Record?.Ties ?? 0,
-                    tbaRanking.QualAverage ?? 0,
+                    tbaRanking.QualAverage ?? (sortOrders.Count > 2 ? sortOrders[2] : 0),
                     tbaRanking.Dq ?? 0,
                     tbaRanking.MatchesPlayed ?? 0
                 );


### PR DESCRIPTION
This covers prior commits as well.

- Add RemapTeams property to TBAEvent and RawTbaEvent models to capture team mapping data
- Add new endpoint GET /v3/{year}/offseason/event/{eventCode} to fetch individual event details from TBA
- Update HybridTeam.TeamNumber type from int to object to support both numeric and alphanumeric team identifiers (e.g., 254 and "971B")
- Update TeamRanking.TeamNumber type from int to object for consistency with team remapping
- Modify team parsing logic in CreateHybridMatch to preserve alphanumeric team keys from TBA (e.g., frc971B → "971B")
- Update offseason rankings endpoint to handle remapped teams instead of skipping them
- Add fallback logic for QualAverage to use sortOrders[2] when qual_average is null in TBA response

This enables proper handling of offseason events where teams field multiple robots (e.g., Madtown Throwdown) by preserving TBA's remapped team identifiers throughout schedules, rankings, and event data.

Maintains backward compatibility: standard numeric teams continue to serialize as integers, while remapped teams serialize as strings.