### PR TITLE
Reducing team list cache to five minutes from one week

### DIFF
--- a/Attributes/RedisCacheAttribute.cs
+++ b/Attributes/RedisCacheAttribute.cs
@@ -104,7 +104,6 @@ public static class RedisCacheTime
 {
     public const int OneMinute = 1;
     public const int FiveMinutes = OneMinute * 5;
-    public const int ThirtyMinutes = OneMinute * 30;
     public const int OneHour = OneMinute * 60;
     public const int OneDay = OneHour * 24;
     public const int ThreeDays = OneDay * 3;

--- a/Controllers/FTCApiController.cs
+++ b/Controllers/FTCApiController.cs
@@ -22,7 +22,7 @@ public class FtcApiController(
     private readonly IDatabase _redis = connectionMultiplexer.GetDatabase();
 
     [HttpGet("teams")]
-    [RedisCache("ftcapi:teams", RedisCacheTime.FiveMinutesMinutes)]
+    [RedisCache("ftcapi:teams", RedisCacheTime.FiveMinutes)]
     [OpenApiTag("FTC Team Data")]
     [ProducesResponseType(typeof(JsonObject), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]


### PR DESCRIPTION
Events were unable to see registered teams at events due to cached team lists. This should help.