### PR TITLE
Fixing a 400 error in the team update history endpoint

### DIFF
--- a/Controllers/FTCTeamUpdatesController.cs
+++ b/Controllers/FTCTeamUpdatesController.cs
@@ -86,7 +86,7 @@ public class FtcTeamUpdatesController(UserStorageService userStorage, TeamDataSe
         var teamList = await teamData.GetFtcTeamData(year, eventCode);
         if (teamList == null) return NoContent();
 
-        var teamNumbers = teamList["teams"]?.AsArray().Select(t => t?["teamNumber"]?.ToString());
+        var teamNumbers = teamList["teams"]?.AsArray()?.Select(t => t?["teamNumber"]?.ToString());
         if (teamNumbers == null) return NoContent();
         var tasks = teamNumbers.Select(async t =>
         {

--- a/Services/UserStorageService.cs
+++ b/Services/UserStorageService.cs
@@ -241,7 +241,7 @@ public class UserStorageService(
                 ContinuationToken = continuationToken
             });
 
-            keys.AddRange(response.S3Objects.Select(o => o.Key));
+            keys.AddRange(response.S3Objects?.Select(o => o.Key) ?? []);
             continuationToken = response.IsTruncated == true ? response.NextContinuationToken : null;
         } while (continuationToken != null);
 


### PR DESCRIPTION
We were getting a 400 error when there were no prior team updates. I think we need to return an empty array.